### PR TITLE
Improve equivalence URL parsing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -172,3 +172,4 @@ dmypy.json
 # more patterns
 *.zip
 .~*
+equivalence_analysis.xlsx

--- a/codex-requirements.txt
+++ b/codex-requirements.txt
@@ -1,1 +1,2 @@
 pandas
+openpyxl

--- a/stats.tsv
+++ b/stats.tsv
@@ -1,0 +1,13 @@
+mode	flavor	count
+asserted-only	LOINC-primary	2
+asserted-only	LOINC-supplementary	110271
+asserted-only	LOINCSNOMED-primary	331
+asserted-only	LOINCSNOMED-supplementary	110596
+asserted-only	all-primary	496
+asserted-only	all-supplementary	0
+none	all-primary	6583
+none	all-suppl	116836
+none	loinc-primary	2
+none	loinc-suppl	110271
+none	loincsnomed-primary	6418
+none	loincsnomed-suppl	116683

--- a/temp_equivalence_analysis.py
+++ b/temp_equivalence_analysis.py
@@ -1,0 +1,56 @@
+import re
+import pandas as pd
+from pathlib import Path
+
+# Pattern for lines with an equivalence statement. Capture both URLs
+# and later extract the terminating code segment from each.
+EQ_PATTERN = re.compile(r"ERROR Equivalence: <([^>]+)> == <([^>]+)>")
+
+ROOT = Path(__file__).resolve().parent
+
+# Load labels
+labels_path = ROOT / "labels.tsv"
+if labels_path.exists():
+    labels_df = pd.read_csv(labels_path, sep="\t")
+else:
+    labels_df = pd.DataFrame(columns=["cls", "label"])
+labels_map = dict(zip(labels_df["cls"], labels_df["label"]))
+
+# Gather log files
+log_files = sorted(p for p in ROOT.glob("*--*.txt") if p.is_file())
+
+stats_rows = []
+frames = {}
+for log_path in log_files:
+    # Use the filename to get mode and flavor; split on the first '--'
+    parts = log_path.stem.split("--", 1)
+    if len(parts) != 2:
+        continue
+    mode, flavor = parts
+
+    rows = []
+    with log_path.open() as f:
+        for line in f:
+            m = EQ_PATTERN.search(line)
+            if m:
+                url1, url2 = m.groups()
+                cls1 = url1.rsplit("/", 1)[-1]
+                cls2 = url2.rsplit("/", 1)[-1]
+                rows.append({
+                    "cls1": cls1,
+                    "cls2": cls2,
+                    "cls1_lab": labels_map.get(cls1, ""),
+                    "cls2_lab": labels_map.get(cls2, "")
+                })
+    df = pd.DataFrame(rows, columns=["cls1", "cls1_lab", "cls2", "cls2_lab"])
+    frames[f"{mode}--{flavor}"] = df
+    stats_rows.append({"mode": mode, "flavor": flavor, "count": len(df)})
+
+# Write stats.tsv
+stats_df = pd.DataFrame(stats_rows)
+stats_df.to_csv(ROOT / "stats.tsv", sep="\t", index=False)
+
+# Write Excel workbook
+with pd.ExcelWriter(ROOT / "equivalence_analysis.xlsx", engine="openpyxl") as writer:
+    for sheet_name, frame in frames.items():
+        frame.to_excel(writer, sheet_name=sheet_name, index=False)


### PR DESCRIPTION
## Summary
- handle equivalence URLs with any domain
- regenerate statistics with new counts

## Testing
- `pip install -r codex-requirements.txt`
- `python temp_equivalence_analysis.py`
- `python -m unittest discover` *(fails: robot.jar not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847565d1d0c832c95b8b4c8a3419ac9