### PR TITLE
Add LOINC release dir variable for groups target

### DIFF
--- a/makefile
+++ b/makefile
@@ -4,7 +4,13 @@
 .PHONY: all build modules grouping dangling merge-reason stats additional-outputs alternative-hierarchies \
 	chebi-subsets
 DEFAULT_BUILD_DIR=output/build-default
+# Directory for dangling analysis outputs
 DANGLING_DIR=output/analysis/dangling
+
+# Resolve the directory name for the default LOINC release using the
+# project's Python configuration.  This is required so that the
+# analysis targets always reference the correct release directory.
+LOINC_DEFAULT_DIR := $(shell python src/loinclib/config.py --method-names get_loinc_default_dir_name)
 # STRICT:
 #  - if true, sets '--equivalent-classes-allowed none' when reasoning.
 #  - Usage: `make STRICT=true merge-reason`
@@ -194,8 +200,8 @@ $(LOINC_OWL_DIR)/loinc-groups.owl: $(LOINC_OWL_DIR)/
 
 output/tmp/loinc-groups.robot.tsv: | output/tmp/
 	python src/comp_loinc/analysis/loinc.py \
-	--group-path loinc_release/AccessoryFiles/GroupFile/Group.csv\
-	--parent-group-path loinc_release/AccessoryFiles/GroupFile/ParentGroup.csv\
+	--group-path loinc_release/$(LOINC_DEFAULT_DIR)/AccessoryFiles/GroupFile/Group.csv\
+	--parent-group-path loinc_release/$(LOINC_DEFAULT_DIR)/AccessoryFiles/GroupFile/ParentGroup.csv\
 	--outpath $@
 
 # TODO: Change LOINC representation. what to do?

--- a/src/loinclib/config.py
+++ b/src/loinclib/config.py
@@ -1,5 +1,7 @@
 import typing as t
 from pathlib import Path
+import argparse
+import os
 
 import yaml
 
@@ -92,3 +94,40 @@ class Configuration:
 
     def get_prop_use_pickle(self) -> Path:
       return self.home_path / self.config["prop_use"]["pickle"]
+
+    def get_loinc_default_dir_name(self) -> str:
+        """Return directory name of the default LOINC release."""
+        path_str = str(self.get_loinc_release_path())
+        marker = "loinc_release" + os.sep
+        idx = path_str.rfind(marker)
+        if idx != -1:
+            return path_str[idx + len(marker) :]
+        return path_str
+
+
+
+def cli() -> None:
+    parser = argparse.ArgumentParser(
+        prog="loinclib-config",
+        description="Utilities for working with comploinc configuration.",
+    )
+    parser.add_argument(
+        "--method-names",
+        nargs="+",
+        help=(
+            "Space-separated Configuration method names to call. "
+            "Each method's return value will be printed on a new line."
+        ),
+    )
+
+    args = parser.parse_args()
+
+    if args.method_names:
+        conf = Configuration(PROJECT_DIR, Path("comploinc_config.yaml"))
+        for name in args.method_names:
+            method = getattr(conf, name)
+            print(method())
+
+
+if __name__ == "__main__":
+    cli()


### PR DESCRIPTION
## Summary
- makefile: add new `LOINC_DEFAULT_DIR` variable computed from configuration
- use it in `loinc-groups.robot.tsv` goal
- add CLI helper `--method-names` in `loinclib.config`

## Testing
- `python -m py_compile src/loinclib/config.py`
- `make -n output/tmp/loinc-groups.robot.tsv`
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_686045452648832cb4859789a330850b