### PR TITLE
Adjust LOINC color range for hierarchy plots

### DIFF
--- a/src/comp_loinc/analysis/depth.py
+++ b/src/comp_loinc/analysis/depth.py
@@ -561,8 +561,13 @@ def _get_plot_colors(df: pd.DataFrame) -> List[str]:
 
         cmap = cmaps.get(ont, plt.cm.Greys)
         for i, col in enumerate(cols):
-            # Spread shades between 0.3 and 0.9 so they remain distinguishable
-            frac = 0.3 + (0.6 * (i / max(n - 1, 1)))
+            # Spread shades between set ranges so they remain distinguishable.
+            # LOINC shades were previously too extreme in brightness, so we
+            # constrain the range used for that ontology.
+            start, end = 0.3, 0.9
+            if ont == "LOINC":
+                start, end = 0.45, 0.75
+            frac = start + ((end - start) * (i / max(n - 1, 1)))
             col_colour_map[col] = to_hex(cmap(frac))
 
     for col in columns:


### PR DESCRIPTION
## Summary
- narrow the LOINC colormap range when plotting depth-by-hierarchy results

## Testing
- `python -m unittest discover` *(fails: Error: Unable to access jarfile /workspace/comp-loinc/robot.jar)*

------
https://chatgpt.com/codex/tasks/task_e_68698f401220832c812b2ba085be421e