### PR TITLE
Fix column order in class depth plots

### DIFF
--- a/src/comp_loinc/analysis/depth.py
+++ b/src/comp_loinc/analysis/depth.py
@@ -716,6 +716,27 @@ def _save_plot(
     merged = pd.DataFrame(data_for_plot).fillna(0)
     merged.index.name = "Depth"
 
+    # Ensure deterministic column ordering.
+    term_order = [
+        "LOINC",
+        "LOINC-SNOMED",
+        "CompLOINC-Primary",
+        "CompLOINC-Supplementary",
+    ]
+
+    def _sort_key(col: str):
+        if disaggregated_subtrees:
+            ont, subtree = col.split(" - ", 1)
+        else:
+            ont, subtree = col, ""
+        try:
+            ont_idx = term_order.index(ont)
+        except ValueError:
+            ont_idx = len(term_order)
+        return (ont_idx, subtree.lower())
+
+    merged = merged[sorted(merged.columns, key=_sort_key)]
+
     # Create bar chart
     bars_direction_map = {'vertical': 'bar', 'horizontal': 'barh'}
     bars_direction = 'horizontal' if disaggregated_subtrees else 'vertical'


### PR DESCRIPTION
## Summary
- ensure deterministic column ordering for depth tables and plots

## Testing
- `pip install -e .` *(fails: BackendUnavailable: Cannot import 'setuptools.build_meta')*

------
https://chatgpt.com/codex/tasks/task_e_686aea55bc2c832c99ff7c2f684ff4ee